### PR TITLE
Add ability to specify custom 'billTo' information

### DIFF
--- a/src/CIMGateway.php
+++ b/src/CIMGateway.php
@@ -9,9 +9,41 @@ use Omnipay\AuthorizeNet\Message\CIMCreateCardRequest;
  */
 class CIMGateway extends AIMGateway
 {
+    public function getDefaultParameters()
+    {
+        return array(
+            'apiLoginId' => '',
+            'transactionKey' => '',
+            'testMode' => false,
+            'developerMode' => false,
+            'forceCardUpdate' => false,
+            'defaultBillTo' => [[]]
+        );
+    }
+
     public function getName()
     {
         return 'Authorize.Net CIM';
+    }
+
+    public function setForceCardUpdate($forceCardUpdate)
+    {
+        return $this->setParameter('forceCardUpdate', $forceCardUpdate);
+    }
+
+    public function getForceCardUpdate()
+    {
+        return $this->getParameter('forceCardUpdate');
+    }
+
+    public function setDefaultBillTo($defaultBillTo)
+    {
+        return $this->setParameter('defaultBillTo', $defaultBillTo);
+    }
+
+    public function getDefaultBillTo()
+    {
+        return $this->getParameter('defaultBillTo');
     }
 
     /**
@@ -44,5 +76,10 @@ class CIMGateway extends AIMGateway
     public function refund(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\AuthorizeNet\Message\CIMRefundRequest', $parameters);
+    }
+
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\AuthorizeNet\Message\CIMVoidRequest', $parameters);
     }
 }

--- a/src/Message/CIMAbstractRequest.php
+++ b/src/Message/CIMAbstractRequest.php
@@ -67,6 +67,16 @@ abstract class CIMAbstractRequest extends AIMAbstractRequest
         return $this->getParameter('forceCardUpdate');
     }
 
+    public function setPopulateBillTo($populateBillTo)
+    {
+        return $this->setParameter('populateBillTo', $populateBillTo);
+    }
+
+    public function getPopulateBillTo()
+    {
+        return $this->getParameter('populateBillTo');
+    }
+
     /**
      * Create and return the base XML data required to create a new request
      *

--- a/src/Message/CIMAbstractRequest.php
+++ b/src/Message/CIMAbstractRequest.php
@@ -67,14 +67,14 @@ abstract class CIMAbstractRequest extends AIMAbstractRequest
         return $this->getParameter('forceCardUpdate');
     }
 
-    public function setPopulateBillTo($populateBillTo)
+    public function setDefaultBillTo($defaultBillTo)
     {
-        return $this->setParameter('populateBillTo', $populateBillTo);
+        return $this->setParameter('defaultBillTo', $defaultBillTo);
     }
 
-    public function getPopulateBillTo()
+    public function getDefaultBillTo()
     {
-        return $this->getParameter('populateBillTo');
+        return $this->getParameter('defaultBillTo');
     }
 
     /**

--- a/src/Message/CIMCreateCardRequest.php
+++ b/src/Message/CIMCreateCardRequest.php
@@ -88,6 +88,18 @@ class CIMCreateCardRequest extends CIMAbstractRequest
             $req->zip = $card->getBillingPostcode();
             $req->country = $card->getBillingCountry();
 
+            $populateBillTo = $this->getParameter('populateBillTo');
+            if (is_array($populateBillTo)) {
+                // A configuration parameter to populate billTo has been specified
+                foreach ($populateBillTo as $field => $value) {
+                    if (empty($req->{$field}) && !empty($value)) {
+                        // This particular field is empty and default value in populateBillTo has been specified
+                        // so use it
+                        $req->{$field} = $value;
+                    }
+                }
+            }
+
             $req = $data->addChild('payment');
             $req->creditCard->cardNumber = $card->getNumber();
             $req->creditCard->expirationDate = $card->getExpiryDate('Y-m');

--- a/src/Message/CIMCreateCardRequest.php
+++ b/src/Message/CIMCreateCardRequest.php
@@ -88,10 +88,10 @@ class CIMCreateCardRequest extends CIMAbstractRequest
             $req->zip = $card->getBillingPostcode();
             $req->country = $card->getBillingCountry();
 
-            $populateBillTo = $this->getParameter('populateBillTo');
-            if (is_array($populateBillTo)) {
+            $defaultBillTo = $this->getParameter('defaultBillTo');
+            if (is_array($defaultBillTo)) {
                 // A configuration parameter to populate billTo has been specified
-                foreach ($populateBillTo as $field => $value) {
+                foreach ($defaultBillTo as $field => $value) {
                     if (empty($req->{$field}) && !empty($value)) {
                         // This particular field is empty and default value in populateBillTo has been specified
                         // so use it

--- a/src/Message/CIMVoidRequest.php
+++ b/src/Message/CIMVoidRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Omnipay\AuthorizeNet\Message;
+
+/**
+ * Authorize.Net CIM Void Request
+ */
+class CIMVoidRequest extends CIMAbstractRequest
+{
+    protected $action = 'voidTransaction';
+
+    public function getData()
+    {
+        $this->validate('transactionReference');
+
+        $data = $this->getBaseData();
+        $data->transactionRequest->refTransId = $this->getTransactionReference();
+        $this->addTestModeSetting($data);
+
+        return $data;
+    }
+}

--- a/tests/CIMGatewayTest.php
+++ b/tests/CIMGatewayTest.php
@@ -38,12 +38,6 @@ class CIMGatewayTest extends GatewayTestCase
             'transactionReference' => '{"approvalCode":"DMK100","transId":"2220001902","cardReference":"{\"customerProfileId\":\"28972084\",\"customerPaymentProfileId\":\"26317840\",\"customerShippingAddressId\":\"27057149\"}"}',
         );
 
-        $this->authorizeOptions = array(
-            'cardReference' => '{"customerProfileId":"28972084","customerPaymentProfileId":"26317840","customerShippingAddressId":"27057149"}',
-            'amount' => 10.00,
-            'description' => 'purchase'
-        );
-
         $this->refundOptions = array(
             'amount' => '10.00',
             'transactionReference' => '{"approvalCode":"DMK100","transId":"2220001902","cardReference":"{\"customerProfileId\":\"28972084\",\"customerPaymentProfileId\":\"26317840\",\"customerShippingAddressId\":\"27057149\"}"}',

--- a/tests/Message/CIMCreateCardRequestTest.php
+++ b/tests/Message/CIMCreateCardRequestTest.php
@@ -42,7 +42,7 @@ class CIMCreateCardRequestTest extends TestCase
                 'card' => $card,
                 'developerMode' => true,
                 'forceCardUpdate' => true,
-                'populateBillTo' => [
+                'defaultBillTo' => [
                     'address' => '1234 Test Street',
                     'city' => 'Blacksburg'
                 ]

--- a/tests/Message/CIMCreateCardRequestTest.php
+++ b/tests/Message/CIMCreateCardRequestTest.php
@@ -29,4 +29,29 @@ class CIMCreateCardRequestTest extends TestCase
         $this->assertEquals($card['number'], $data->profile->paymentProfiles->payment->creditCard->cardNumber);
         $this->assertEquals('testMode', $data->validationMode);
     }
+
+    public function testGetDataShouldHaveCustomBillTo()
+    {
+        $card = $this->getValidCard();
+        unset($card['billingAddress1']);
+        unset($card['billingAddress2']);
+        unset($card['billingCity']);
+        $this->request->initialize(
+            array(
+                'email' => "kaylee@serenity.com",
+                'card' => $card,
+                'developerMode' => true,
+                'forceCardUpdate' => true,
+                'populateBillTo' => [
+                    'address' => '1234 Test Street',
+                    'city' => 'Blacksburg'
+                ]
+            )
+        );
+
+        $data = $this->request->getData();
+        $this->assertEquals('12345', $data->profile->paymentProfiles->billTo->zip);
+        $this->assertEquals('1234 Test Street', $data->profile->paymentProfiles->billTo->address);
+        $this->assertEquals('Blacksburg', $data->profile->paymentProfiles->billTo->city);
+    }
 }


### PR DESCRIPTION
Authorize.net CIM requires billTo address be present when creating a
payment profile. Sometimes you don't have a billing address so this
allows you to specify a default/custom billing address to be submitted
with the create card request