### PR TITLE
Add customer email support to the customer object

### DIFF
--- a/src/Message/AIMAbstractRequest.php
+++ b/src/Message/AIMAbstractRequest.php
@@ -98,9 +98,12 @@ abstract class AIMAbstractRequest extends AbstractRequest
         $req = $data->transactionRequest;
 
         // Merchant assigned customer ID
-        $customer = $this->getCustomerId();
-        if (!empty($customer)) {
-            $req->customer->id = $customer;
+        if (!empty($this->getCustomerId())) {
+            $req->customer->id = $this->getCustomerId();
+        }
+
+        if (!empty($this->getEmail())) {
+            $req->customer->email = $this->getEmail();
         }
 
         /** @var CreditCard $card */


### PR DESCRIPTION
Email in some cases is required if no customer ID is provided. For example for guest users.